### PR TITLE
Fix cell editing clearing existing data

### DIFF
--- a/app/features/header.tsx
+++ b/app/features/header.tsx
@@ -55,7 +55,7 @@ const Header: React.FC<HeaderProps> = ({
     if (typeof window !== "undefined" && !user) {
       const storedUser = localStorage.getItem("user-storage");
       if (!storedUser) {
-        login(staticUsers[0]); // Default to first user
+        login(staticUsers[0]);
       }
     }
   }, [user, login]);

--- a/app/spreadsheets/[id]/SpreadsheetsPage.tsx
+++ b/app/spreadsheets/[id]/SpreadsheetsPage.tsx
@@ -25,7 +25,7 @@ import { useSkipper } from "@/lib/hooks";
 
 declare module "@tanstack/react-table" {
   interface TableMeta<TData extends RowData> {
-    updateData: (rowIndex: number, columnId: string, value: Cell) => void;
+    updateData: (rowIndex: number, columnId: string, value: string) => void;
   }
 }
 
@@ -46,11 +46,7 @@ function EditableCell<TData extends Record<string, Cell>>({
   const cellId = `cell-${row.index}-${column.id}`;
 
   const onBlur = () => {
-    table.options.meta?.updateData(
-      row.index,
-      column.id,
-      value as unknown as Cell
-    );
+    table.options.meta?.updateData(row.index, column.id, value);
     setIsActive(false);
   };
 
@@ -61,7 +57,7 @@ function EditableCell<TData extends Record<string, Cell>>({
   return (
     <div className="relative w-full h-full" id={cellId}>
       <input
-        value={value as string}
+        value={value}
         onChange={(e) => setValue(e.target.value)}
         onFocus={() => setIsActive(true)}
         onBlur={onBlur}
@@ -113,14 +109,14 @@ export function SpreadsheetPage({
   const [autoResetPageIndex, skipAutoResetPageIndex] = useSkipper();
 
   const updateData = debounce(
-    (rowIndex: number, columnId: string, value: Cell) => {
+    (rowIndex: number, columnId: string, value: string) => {
       skipAutoResetPageIndex();
       setData((old) =>
         old.map((row, index) => {
           if (index === rowIndex) {
             return {
               ...old[rowIndex]!,
-              [columnId]: value as Cell,
+              [columnId]: { value },
             } as Record<string, Cell>;
           }
           return row;


### PR DESCRIPTION
## Description:
This PR fixes an issue where editing a cell would clear existing data due to incorrect handling of Cell objects. The changes modify the updateData function and related types to properly handle string values while maintaining the Cell object structure.

Changes:

Modified updateData to accept string values and create proper Cell objects
Updated EditableCell to work with string values directly
Adjusted TableMeta interface to reflect correct typing
Removed unnecessary type casting
Testing:

Verify that editing a cell updates its value without clearing other cells
Confirm that existing data persists after edits
Check that new values are properly saved in the Cell object format