### PR TITLE
fix: add attribute on each element you want to add comments on

### DIFF
--- a/app/spreadsheets/[id]/SpreadsheetsPage.tsx
+++ b/app/spreadsheets/[id]/SpreadsheetsPage.tsx
@@ -221,6 +221,7 @@ export function SpreadsheetPage({
                   {row.getVisibleCells().map((cell) => (
                     <div
                       key={cell.id}
+                      data-velt-target-comment-element-id={cell.id}
                       style={{ width: `${cell.column.getSize()}px` }}
                       className="border-r border-gray-200 h-6 overflow-hidden"
                     >


### PR DESCRIPTION
Add data-velt-target-comment-element-id as an attribute on each element you want to add comments on.

Now, when you click on the Comment Tool and click on the target element, it will attach a Popover comment to the element.